### PR TITLE
perf: removed Thread.sleep from monitoring loop for real-time execution

### DIFF
--- a/metrics-backend/data-collector/src/main/java/kr/cs/interdata/datacollector/DataCollectorApplication.java
+++ b/metrics-backend/data-collector/src/main/java/kr/cs/interdata/datacollector/DataCollectorApplication.java
@@ -107,8 +107,6 @@ class KafkaProducerRunner implements CommandLineRunner {
                         System.out.println("Kafka 전송 성공: " + metadata.topic() + " offset=" + metadata.offset());
                     }
                 });
-
-                Thread.sleep(1000);
             }
         }
     }


### PR DESCRIPTION
<변경 내용>
DataCollectorApplication 클래스의 while 루프 내부에서 Thread.sleep(1000)으로 1초씩 대기하던 부분을 제거했습니다.

<변경 이유>
실제로 데이터를 수집하는 데 약 5초가 소요되는 것을 확인했습니다.
따라서 굳이 1초를 더 대기할 필요가 없다고 판단하여, 반복문 내부의 지연을 제거함으로써 불필요한 대기 시간을 줄이고 전체 실행 흐름을 간소화했습니다.
데이터 수집하는데 약 5초가 걸린다는 점을 개선할 방안은 조금 더 생각을 해봐야할거 같습니다.