### PR TITLE
시스템 상태 파일 파싱 로직에 상세 주석 추가

### DIFF
--- a/metrics-backend/data-collector/src/main/java/kr/cs/interdata/datacollector/MachineNetworkMonitor.java
+++ b/metrics-backend/data-collector/src/main/java/kr/cs/interdata/datacollector/MachineNetworkMonitor.java
@@ -23,6 +23,8 @@ public class MachineNetworkMonitor {
             return result;
         }
 
+        //참고) 제일 밑에 /proc/net/dev 파일 구조와 각 필드가 의미하는 내용있습니다!
+
         // 첫 두 줄은 헤더이므로 건너뜀
         for (int i = 2; i < lines.size(); i++) {
             String line = lines.get(i).trim();
@@ -56,3 +58,35 @@ public class MachineNetworkMonitor {
         return result;
     }
 }
+
+/*
+ * ┌──────────────────────────────────── /proc/net/dev 구조 설명 ─────────────────────────────────────┐
+ *
+ *  # Sample (/proc/net/dev) file excerpt:
+ *  Inter-|   Receive                                                |  Transmit
+ *   face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+ *   eth0: 268524460 366503    0    0    0     0          0         0    25345645  348070    0    0    0     0      0          0
+ *     lo:   134526     140    0    0    0     0          0         0      134526     140    0    0    0     0      0          0
+ *
+ *  필드 별 인덱스 및 의미 (양쪽 공백/콜론 기준 split 후):
+ *   - 인덱스 0~7 : 수신(Receive) 통계
+ *        [0] bytes        : 누적 수신 바이트
+ *        [1] packets      : 누적 수신 패킷 수
+ *        [2] errs         : 수신 오류
+ *        [3] drop         : 수신 drop 패킷 수
+ *        [4] fifo         : 수신 fifo 에러
+ *        [5] frame        : 수신 frame 에러
+ *        [6] compressed   : 수신 압축 패킷 수
+ *        [7] multicast    : 수신 멀티캐스트 패킷 수
+ *   - 인덱스 8~15 : 송신(Transmit) 통계
+ *        [8] bytes        : 누적 송신 바이트
+ *        [9] packets      : 누적 송신 패킷 수
+ *       [10] errs         : 송신 오류
+ *       [11] drop         : 송신 drop 패킷 수
+ *       [12] fifo         : 송신 fifo 에러
+ *       [13] colls        : 송신 충돌(collision) 횟수
+ *       [14] carrier      : 캐리어 에러
+ *       [15] compressed   : 송신 압축 패킷 수
+ *
+ * └─────────────────────────────────────────────────────────────────────────────────────────────┘
+ */


### PR DESCRIPTION
### 변경 요약
---
- /proc/net/dev 등 주요 리눅스 시스템 정보 파일 파싱 부분에 각 필드의 의미와 구조를 설명하는 상세 주석(블록 주석) 추가

- Receive/Transmit 통계 인덱스, 단위, 용도 등 명확히 명시

- 신규/기존 개발자도 파싱 코드의 동작 방식과 데이터를 쉽게 이해할 수 있도록 가독성 및 유지보수성 개선


### 세부 변경 내용
---
- 네트워크(/proc/net/dev), 메모리(/proc/meminfo), CPU(/proc/stat) 등 파싱 코드 상단 또는 함수에 구조 설명용 블록주석 추가

- 각 데이터 라인에서 읽어오는 인덱스별 필드명과 실제 의미를 정리

### 주요 목적
---
- 코드 리뷰, 협업, 미래 유지보수를 위해 시스템 파일의 데이터 구조 및 파싱 로직에 대한 문서화 강화

### 참고 사항
---
- 코드 동작(파싱 및 결과 JSON 등)에는 변경 없음, 주석만 추가된 PR입니다.