### PR TITLE
fix(notification): Prevent spurious SSE alerts on page refresh

### DIFF
--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
@@ -419,10 +419,7 @@ public class ThresholdService {
             // ContainerInventory 엔티티의 machineId와 machineName을 파싱해서 둘 조합이 있으면 종속된 hostName을 넘겨줌
             String hostName;
             if (log.getMachineType().equals("container")) {
-                hostName = containerInventoryService.addHostNameByContainerIdAndContainerName(
-                        log.getMachineId(),
-                        log.getMachineName()
-                );
+                hostName = containerInventoryService.getHostNameByContainerId(log.getMachineId());
             } else {
                 hostName = log.getMachineName();
             }

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
@@ -330,6 +330,13 @@ public class ThresholdService {
                             map.put("threshold", log.getThreshold());
                             map.put("value", log.getValue());
                             map.put("timestamp", log.getTimestamp());
+
+                            if (log.getTimestamp() != null) {
+                                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+                                map.put("timestamp", log.getTimestamp().format(formatter));
+                            } else {
+                                map.put("timestamp", null);
+                            }
                             return map;
                         } catch (Exception e) {
                             System.out.println("[ERROR] map 변환 중 오류 발생: " + e.getMessage());


### PR DESCRIPTION
### 문제 상황 
- 이상 알림 페이지를 새로고침할 때마다, 특정 컨테이너(mysql-db, api-backend)의 네트워크 트래픽에 대한 잘못된 이상 알림이 SSE를 통해 발생하는 버그가 있었습니다.
- 이 가짜 알림은 실제 값과 다른 값을 표시하며, 타임스탬프는 실제 이벤트 시간이 아닌 페이지를 새로고침한 시점으로 기록되었습니다.
- 해당 페이지에는 SSE 연결 코드가 없지만, 전역 SSE 서비스가 이 잘못된 데이터를 감지하여 알림을 보내는 구조였습니다.

### 변경 사항 
- getMapList 메서드에서 컨테이너의 호스트 이름을 가져오는 로직을 리팩토링했습니다.
- 부수 효과를 유발하던 기존 로직 대신, 컨테이너 ID를 통해 호스트 이름만 안전하게 조회하는 containerInventoryService.getHostNameByContainerId() 메서드를 사용하도록 변경했습니다.