### PR TITLE
날짜 단독 필터 시 최신순 50개 조회 개선

### DIFF
--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/repository/AbnormalMetricLogRepository.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/repository/AbnormalMetricLogRepository.java
@@ -37,6 +37,13 @@ public interface AbnormalMetricLogRepository extends JpaRepository<AbnormalMetri
 
     List<AbnormalMetricLog> findTop50ByMetricNameOrderByTimestampDesc(String metricName);
 
+    @Query("SELECT l FROM AbnormalMetricLog l WHERE l.timestamp BETWEEN :start AND :end ORDER BY l.timestamp DESC")
+    List<AbnormalMetricLog> findByTimestampBetweenOrderByTimestampDesc(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
+
+
     @Query("SELECT l FROM AbnormalMetricLog l " +
             "WHERE (:start IS NULL OR l.timestamp >= :start) " +
             "AND (:end IS NULL OR l.timestamp <= :end) " +

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
@@ -300,8 +300,8 @@ public class ThresholdService {
             List<AbnormalMetricLog> logs;
 
             if (isOnlyDate) {
-                System.out.println("[INFO] 날짜만 들어온 요청입니다 🗓️");
-                logs = abnormalMetricLogRepository.findByTimestampBetween(start, end);
+                System.out.println("[INFO] 날짜만 들어온 요청입니다 ");
+                logs=abnormalMetricLogRepository.findByTimestampBetweenOrderByTimestampDesc(start, end);
             } else {
                 logs = abnormalMetricLogRepository.findFilteredLogs(
                         start,


### PR DESCRIPTION
### 개요
- 이 PR은 이상 로그 이력 조회 로직에서 날짜 필터만 사용 시 최신순 50개 로그가 정상적으로 반환되지 않던 문제를 해결합니다.

### 주요 변경 사항
- 날짜 단독 필터 최신순 조회 개선
- Repository에 findByTimestampBetweenOrderByTimestampDesc 메서드(JPQL 쿼리)를 추가하여,
날짜 범위 내에서 timestamp DESC(최신순) 50개가 반환되도록 수정

### 영향 및 기대 효과
- 이상 내역 페이지에서 날짜만 선택해도 가장 최근(최신순) 50개 로그가 정확히 노출됩니다.
- 특정 시간 이후의 이상 이벤트 미표시 문제 해결