### PR TITLE
이상 로그 저장 hostName 누락 이슈 해결

### DIFF
--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/repository/ContainerInventoryRepository.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/repository/ContainerInventoryRepository.java
@@ -43,4 +43,7 @@ public interface ContainerInventoryRepository extends JpaRepository<ContainerInv
 
     @Query("SELECT c.hostName FROM ContainerInventory c WHERE c.containerId = :containerId")
     String findHostNameByContainerId(@Param("containerId") String containerId);
+
+    @Query("SELECT c.hostName FROM ContainerInventory c WHERE c.containerName = :containerName")
+    String findHostNameByContainerName(@Param("containerName") String containerName);
 }

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/repository_service/AbnormalDetectionService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/repository_service/AbnormalDetectionService.java
@@ -291,17 +291,17 @@ public class AbnormalDetectionService {
         logger.info("[이상로그삭제] 7일 이상된 로그 {} 건 삭제 완료", deleted);
     }
 
+
+
     private String resolveHostName(String machineType, String machineId, String machineName) {
         if ("host".equalsIgnoreCase(machineType)) {
             return machineName;
         } else if ("container".equalsIgnoreCase(machineType)) {
-            return containerInventoryService.getHostNameByContainerId(machineId);
+            return containerInventoryService.fallbackHostName(machineId,machineName);
         } else {
             return "unknown";
         }
     }
-
-
 }
 
 

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/repository_service/ContainerInventoryService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/repository_service/ContainerInventoryService.java
@@ -39,6 +39,18 @@ public class ContainerInventoryService {
         return (hostName != null) ? hostName : "unknown"; // null-safe 처리
     }
 
+    public String fallbackHostName(String containerId, String containerName) {
+        String hostName = null;
+        if (containerId != null) {
+            hostName = containerInventoryRepository.findHostNameByContainerIdAndContainerName(containerId, containerName);
+        }
+        if (hostName == null && containerName != null) {
+            hostName = containerInventoryRepository.findHostNameByContainerName(containerName);
+        }
+        return (hostName != null) ? hostName : "unknown";
+    }
+
+
 
 
 }


### PR DESCRIPTION
## 개요
- 이 PR은 이상 로그(AbnormalMetricLog) 저장 시 컨테이너의 hostName을 보다 정확히 매핑하여 저장하는 로직을 추가/개선한 내용입니다.  
- 기존에는 컨테이너 관련 이벤트(`containerIdChanged`, `timeout`, `zerovalue` 등) 발생 시 hostName이 `"unknown"`으로 저장되는 경우가 많았으나,  이제 inventory에 등록된 containerId, containerName을 근거로 최대한 hostName을 직접 채워 넣습니다.

## 주요 변경 사항
- **AbnormalDetectionService**
    - `resolveHostName` 함수가 컨테이너 타입일 때 `containerInventoryService.fallbackHostName()`을 호출하여 hostName을 매핑하도록 수정
    - 모든 이상 이벤트 저장 함수(`storeThresholdExceeded`, `storeThresholdDeceeded`, `storeZeroValue`, `storeContainerIdChanged`, `storeTimeout`)에서 일관적으로 개선된 hostName 매핑 메커니즘 적용

- **ContainerInventoryService**
    - `fallbackHostName` 함수 신규/보완:  
      1. containerId + containerName 쌍으로 hostName을 최대한 찾고  
      2. 실패 시 containerName만으로도 조회하며  
      3. 그래도 없으면 `"unknown"` 적용

- **ContainerInventoryRepository**
    - `findHostNameByContainerName` 쿼리 메서드 추가  
      (containerName만으로 hostName 단건 조회 가능)

## 기대 효과

- **이상 로그 기록 시 hostName 누락("unknown") 사례가 크게 줄어듦**
- `containerIdChanged` 등 컨테이너 상태 변화 이벤트에서도 hostName이 제대로 기록됨
- 향후 inventory 확장이나 데이터 정비에도 일관성 유지 및 디버깅 용이

## 참고

- 이 변경은 **PR 병합/배포 이후 새로 저장되는 이상 로그부터 적용**됨
- 기존(2025.7.25 이전) abnormal 로그의 hostName "unknown"은 데이터 정정 SQL 또는 별도 배치로 보정 필요

## 테스트 및 검증

- 실제 컨테이너 이벤트 발생 시 postman에서 hostName 정상 반영 여부 확인