### PR TITLE
스케줄러 주기 및 타임아웃 임계값 조정

### DIFF
--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/MetricMonitorService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/MetricMonitorService.java
@@ -87,7 +87,7 @@ public class MetricMonitorService {
             String key = entry.getKey();
             MachineMetricTimestamp data = entry.getValue();
 
-            if (Duration.between(data.getTimestamp(), now).toSeconds() >= 60) {
+            if (Duration.between(data.getTimestamp(), now).toSeconds() >= 10) {
                 // key 형식: type:machineName:parentHostName
                 String[] parts = key.split(":", 3);
                 String type = parts[0];

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/MetricMonitorService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/MetricMonitorService.java
@@ -95,6 +95,8 @@ public class MetricMonitorService {
 
                 thresholdService.storeTimeout(type, data.getMachineId(), data.getMachineName(), now);
 
+                metricTimestampCache.invalidate(key);
+
                 logger.warn("store timeout for machineName={} type={} parentHostName={}", parts[1], type, parentHostName);
             }
         }

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/MetricMonitorService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/MetricMonitorService.java
@@ -78,7 +78,7 @@ public class MetricMonitorService {
     }
 
     // 감시용 스케줄러
-    @Scheduled(fixedRate = 30_000)
+    @Scheduled(fixedRate = 10_000)
     public void checkMetricTimeouts() {
         LocalDateTime now = LocalDateTime.now();
         Map<String, MachineMetricTimestamp> snapshot = metricTimestampCache.asMap();


### PR DESCRIPTION
##  타임아웃 감지 시간 조정

### 변경 이유

기존 설정에서는 **타임아웃 감지 시간이 너무 느려**, 실제 연결 종료 시점과 시스템 인식 시점 사이의 지연이 컸습니다.

###  변경 전

* **타임아웃 판별 기준:** 60초 이상 데이터 미수신 시
* **스케줄러 간격:** 30초
* **최대 감지 지연 시간:** 약 1분 30초

### 변경 후

* **타임아웃 판별 기준:** 10초 이상 데이터 미수신 시
* **스케줄러 간격:** 10초
* **최대 감지 지연 시간:** 약 20초

### 참고
- 지금 값은 임의의 값이므로 필요에 따라 api-backend내의  MetricMonitorService.java에서 수정 가능
